### PR TITLE
Colibre dev03

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Then, to generate the comparison data;
 
 ```
 cd velociraptor-comparison-data
+git pull origin master
 bash convert.sh
 cd ..
 ```

--- a/data_conversion/description.py
+++ b/data_conversion/description.py
@@ -22,7 +22,9 @@ def latex_float(f):
 
 
 data = load(sys.argv[1])
-with open(sys.argv[2], "r") as handle:
+ymlfile = sys.argv[2]
+
+with open(ymlfile, "r") as handle:
     parameter_file = yaml.load(handle, Loader=yaml.Loader)
 
 with open("boxsize_integer.txt", "w") as handle:
@@ -58,17 +60,36 @@ output = f"""<ul>
 <li><b>Hydrodynamics</b>: {data.metadata.hydro_info}</li>
 <li><b>Key parameters</b>:
   <ul>
-    <li>$f_{{\\rm E, min}} = {parameter_file['EAGLEFeedback']['SNII_energy_fraction_min']:.4g}$</li>
-    <li>$f_{{\\rm E, max}} = {parameter_file['EAGLEFeedback']['SNII_energy_fraction_max']:.4g}$</li>
-    <li>$n_Z = {parameter_file['EAGLEFeedback']['SNII_energy_fraction_n_Z']:.4g}$</li>
-    <li>$n_0 = {parameter_file['EAGLEFeedback']['SNII_energy_fraction_n_0_H_p_cm3']:.4g}$</li>
-    <li>$n_n = {parameter_file['EAGLEFeedback']['SNII_energy_fraction_n_n']:.4g}$</li>
-    <li>AGN $\\mathrm{{d}}T = {latex_float(parameter_file['EAGLEAGN']['AGN_delta_T_K'])}$ ($\\log_{{10}}(\\mathrm{{d}}T / K) = {parameter_file['EAGLEAGN']['AGN_delta_T_K']:.4g}$)</li>
-    <li>AGN $C_{{\\rm eff}} = {parameter_file['EAGLEAGN']['coupling_efficiency']:.4g}$</li>
-    <li>AGN Visocous $\\alpha = {latex_float(parameter_file['EAGLEAGN']['viscous_alpha'])}$</li>
-  </ul>
-</ul>
 """
 
+        
+if 'colibre' in ymlfile:
+        output2 = f"""<ul>
+            <li>$E                 = {parameter_file['COLIBREFeedback']['SNII_energy_erg']}$</li>
+            <li>$f_{{\\rm E, min}} = {parameter_file['COLIBREFeedback']['SNII_energy_fraction_min']:.4g}$</li>
+            <li>$f_{{\\rm E, max}} = {parameter_file['COLIBREFeedback']['SNII_energy_fraction_max']:.4g}$</li>
+            <li>$n_Z = {parameter_file['COLIBREFeedback']['SNII_energy_fraction_n_Z']:.4g}$</li>
+            <li>$n_0 = {parameter_file['COLIBREFeedback']['SNII_energy_fraction_n_0_H_p_cm3']:.4g}$</li>
+            <li>$n_n = {parameter_file['COLIBREFeedback']['SNII_energy_fraction_n_n']:.4g}$</li>
+            <li>AGN $\\mathrm{{d}}T = {parameter_file['EAGLEAGN']['AGN_delta_T_K']}$ ($\\log_{{10}}(\\mathrm{{d}}T / K) = {parameter_file['EAGLEAGN']['AGN_delta_T_K']}$)</li>
+            <li>AGN $C_{{\\rm eff}} = {parameter_file['EAGLEAGN']['coupling_efficiency']:.4g}$</li>
+            <li>AGN Visocous $\\alpha = {parameter_file['EAGLEAGN']['viscous_alpha']}$</li>
+        </ul>
+        </ul>
+       """
+else:
+       output2 = f"""<ul>
+            <li>$f_{{\\rm E, min}} = {parameter_file['EAGLEFeedback']['SNII_energy_fraction_min']:.4g}$</li>
+            <li>$f_{{\\rm E, max}} = {parameter_file['EAGLEFeedback']['SNII_energy_fraction_max']:.4g}$</li>
+            <li>$n_Z = {parameter_file['EAGLEFeedback']['SNII_energy_fraction_n_Z']:.4g}$</li>
+            <li>$n_0 = {parameter_file['EAGLEFeedback']['SNII_energy_fraction_n_0_H_p_cm3']:.4g}$</li>
+            <li>$n_n = {parameter_file['EAGLEFeedback']['SNII_energy_fraction_n_n']:.4g}$</li>
+            <li>AGN $\\mathrm{{d}}T = {latex_float(parameter_file['EAGLEAGN']['AGN_delta_T_K'])}$ ($\\log_{{10}}(\\mathrm{{d}}T / K) = {parameter_file['EAGLEAGN']['AGN_delta_T_K']:.4g}$)</li>
+            <li>AGN $C_{{\\rm eff}} = {parameter_file['EAGLEAGN']['coupling_efficiency']:.4g}$</li>
+            <li>AGN Visocous $\\alpha = {latex_float(parameter_file['EAGLEAGN']['viscous_alpha'])}$</li>
+        </ul>
+        </ul>
+        """
+
 with open("description.html", "w") as handle:
-    handle.write(output)
+    handle.write(output+output2)

--- a/data_conversion/parameters.py
+++ b/data_conversion/parameters.py
@@ -12,17 +12,28 @@ with open(sys.argv[1], "r") as handle:
 parameter_output_filename = "parameters.txt"
 
 agn_parameters = {
-    "dT": f"{input_data['EAGLEAGN']['AGN_delta_T_K']:e}",
+    "dT": f"{float(input_data['EAGLEAGN']['AGN_delta_T_K']):10.3e}",
     "Ceff": f"{input_data['EAGLEAGN']['coupling_efficiency']:3.3f}",
-    "Va": f"{input_data['EAGLEAGN']['viscous_alpha']:e}",
+    "Va": f"{float(input_data['EAGLEAGN']['viscous_alpha']):10.3e}",
 }
-SNII_parameters = {
-    "min": f"{input_data['EAGLEFeedback']['SNII_energy_fraction_min']:3.3f}",
-    "max": f"{input_data['EAGLEFeedback']['SNII_energy_fraction_max']:3.3f}",
-    "n_0": f"{input_data['EAGLEFeedback']['SNII_energy_fraction_n_0_H_p_cm3']:3.3f}",
-    "n_Z": f"{input_data['EAGLEFeedback']['SNII_energy_fraction_n_Z']:3.3f}",
-    "n_n": f"{input_data['EAGLEFeedback']['SNII_energy_fraction_n_n']:3.3f}",
-}
+if 'colibre' in sys.argv[1]:
+    SNII_parameters = {
+        "min": f"{input_data['COLIBREFeedback']['SNII_energy_fraction_min']:3.3f}",
+        "max": f"{input_data['COLIBREFeedback']['SNII_energy_fraction_max']:3.3f}",
+        "n_0": f"{input_data['COLIBREFeedback']['SNII_energy_fraction_n_0_H_p_cm3']:3.3f}",
+        "n_Z": f"{input_data['COLIBREFeedback']['SNII_energy_fraction_n_Z']:3.3f}",
+        "n_n": f"{input_data['COLIBREFeedback']['SNII_energy_fraction_n_n']:3.3f}",
+        "ene": f"{float(input_data['COLIBREFeedback']['SNII_energy_erg']):10.3e}",
+    }
+else:
+    SNII_parameters = {
+        "min": f"{input_data['EAGLEFeedback']['SNII_energy_fraction_min']:3.3f}",
+        "max": f"{input_data['EAGLEFeedback']['SNII_energy_fraction_max']:3.3f}",
+        "n_0": f"{input_data['EAGLEFeedback']['SNII_energy_fraction_n_0_H_p_cm3']:3.3f}",
+        "n_Z": f"{input_data['EAGLEFeedback']['SNII_energy_fraction_n_Z']:3.3f}",
+        "n_n": f"{input_data['EAGLEFeedback']['SNII_energy_fraction_n_n']:3.3f}",
+    }
+
 
 output = ""
 

--- a/image.sh
+++ b/image.sh
@@ -22,12 +22,13 @@ image_run () {
   plot_directory=$3
   snapshot_name=$4
   catalogue_name=$5
+  ptype=$6
 
   catalogue_path=$run_directory/$catalogue_name
   output_path=$plot_directory/$run_name
   snapshot_path=$run_directory/$snapshot_name
 
-  python3 images/imaging.py $snapshot_path $catalogue_path $output_path
+  python3 images/imaging.py $snapshot_path $catalogue_path $output_path $ptype
   python3 images/halo_images.py $snapshot_path $catalogue_path $output_path
 }
 

--- a/plot.sh
+++ b/plot.sh
@@ -22,6 +22,7 @@ plot_run () {
   plot_directory=$3
   snapshot_name=$4
   catalogue_name=$5
+  ptype=$6
 
   catalogue_path=$run_directory/$catalogue_name
   output_path=$plot_directory/$run_name
@@ -63,7 +64,8 @@ plot_run () {
     $run_name \
     $run_directory \
     $snapshot_name \
-    $output_path
+    $output_path \
+    $ptype
 
   python3 plotting/birth_density_distribution.py \
     $run_name \
@@ -75,7 +77,8 @@ plot_run () {
     $run_name \
     $run_directory \
     $snapshot_name \
-    $output_path
+    $output_path \
+    $ptype
 
   python3 performance/number_of_steps_simulation_time.py \
     $run_name \
@@ -112,20 +115,27 @@ create_summary_plot () {
   plot_directory=$3
   snapshot_name=$4
   catalogue_name=$5
+  ptype=$6
 
   output_path=$plot_directory/$run_name
 
   old_directory=$(pwd)
   cd $output_path
 
+  if [ "$ptype" = "COLIBRE" ]; then
+        tstring="colibre"
+  else
+        tstring="eagle"
+  fi
+
   # Copy in the index.html file for summary web viewing
-  cp $run_directory/eagle_*.yml .
-  chmod a+r eagle_*.yml
+  cp $run_directory/$tstring_*.yml .
+  chmod a+r $tstring_*.yml
   cp $old_directory/data_conversion/index.html .
 
-  python3 $old_directory/data_conversion/parameters.py eagle_*.yml
+  python3 $old_directory/data_conversion/parameters.py $tstring_*.yml
   python3 $old_directory/data_conversion/catalogue.py
-  python3 $old_directory/data_conversion/description.py $run_directory/$snapshot_name eagle_*.yml
+  python3 $old_directory/data_conversion/description.py $run_directory/$snapshot_name $tstring_*.yml
 
   sed -i -e "/RUN_DESCRIPTION/r description.html" -e "/RUN_DESCRIPTION/d" index.html
   boxsize=$(cat boxsize_integer.txt)

--- a/plotting/birth_density_metallicity.py
+++ b/plotting/birth_density_metallicity.py
@@ -19,6 +19,7 @@ run_name = sys.argv[1]
 run_directory = sys.argv[2]
 snapshot_name = sys.argv[3]
 output_path = sys.argv[4]
+ptype = sys.argv[5]
 
 snapshot_filename = f"{run_directory}/{snapshot_name}"
 
@@ -26,25 +27,41 @@ plt.style.use("mnras.mplstyle")
 
 data = load(snapshot_filename)
 used_parameters = data.metadata.parameters
-parameters = {
-    k: float(used_parameters[v])
-    for k, v in {
-        "f_E,min": "EAGLEFeedback:SNII_energy_fraction_min",
-        "f_E,max": "EAGLEFeedback:SNII_energy_fraction_max",
-        "n_Z": "EAGLEFeedback:SNII_energy_fraction_n_Z",
-        "n_n": "EAGLEFeedback:SNII_energy_fraction_n_n",
-        "Z_pivot": "EAGLEFeedback:SNII_energy_fraction_Z_0",
-        "n_pivot": "EAGLEFeedback:SNII_energy_fraction_n_0_H_p_cm3",
-    }.items()
-}
-star_formation_parameters = {
-    k: float(used_parameters[v])
-    for k, v in {
-        "threshold_Z0": "EAGLEStarFormation:threshold_Z0",
-        "threshold_n0": "EAGLEStarFormation:threshold_norm_H_p_cm3",
-        "slope": "EAGLEStarFormation:threshold_slope",
-    }.items()
-}
+
+if "COLIBRE" in ptype:
+    parameters = {
+        k: float(used_parameters[v])
+        for k, v in {
+            "f_E,min": "COLIBREFeedback:SNII_energy_fraction_min",
+            "f_E,max": "COLIBREFeedback:SNII_energy_fraction_max",
+            "n_Z": "COLIBREFeedback:SNII_energy_fraction_n_Z",
+            "n_n": "COLIBREFeedback:SNII_energy_fraction_n_n",
+            "Z_pivot": "COLIBREFeedback:SNII_energy_fraction_Z_0",
+            "n_pivot": "COLIBREFeedback:SNII_energy_fraction_n_0_H_p_cm3",
+            "ener": "COLIBREFeedback:SNII_energy_erg",
+        }.items()
+    }
+else:
+    parameters = {
+        k: float(used_parameters[v])
+        for k, v in {
+            "f_E,min": "EAGLEFeedback:SNII_energy_fraction_min",
+            "f_E,max": "EAGLEFeedback:SNII_energy_fraction_max",
+            "n_Z": "EAGLEFeedback:SNII_energy_fraction_n_Z",
+            "n_n": "EAGLEFeedback:SNII_energy_fraction_n_n",
+            "Z_pivot": "EAGLEFeedback:SNII_energy_fraction_Z_0",
+            "n_pivot": "EAGLEFeedback:SNII_energy_fraction_n_0_H_p_cm3",
+        }.items()
+    }
+    star_formation_parameters = {
+        k: float(used_parameters[v])
+        for k, v in {
+            "threshold_Z0": "EAGLEStarFormation:threshold_Z0",
+            "threshold_n0": "EAGLEStarFormation:threshold_norm_H_p_cm3",
+            "slope": "EAGLEStarFormation:threshold_slope",
+        }.items()
+    }
+
 
 number_of_bins = 128
 
@@ -82,24 +99,32 @@ mappable = ax.pcolormesh(
 )
 fig.colorbar(mappable, label="Feedback energy fraction $f_E$", pad=0)
 
-H, _, _ = np.histogram2d(
-    (data.stars.birth_densities / mh).to(1 / cm ** 3).value,
-    data.stars.smoothed_metal_mass_fractions.value,
-    bins=[birth_density_bins.value, metal_mass_fraction_bins.value],
-)
+if "COLIBRE" in ptype:
+    H, _, _ = np.histogram2d(
+        (data.stars.birth_densities / mh).to(1 / cm ** 3).value,
+        data.stars.metal_mass_fractions.value,
+        bins=[birth_density_bins.value, metal_mass_fraction_bins.value],
+    )
+else:
+    H, _, _ = np.histogram2d(
+        (data.stars.birth_densities / mh).to(1 / cm ** 3).value,
+        data.stars.smoothed_metal_mass_fractions.value,
+        bins=[birth_density_bins.value, metal_mass_fraction_bins.value],
+    )
 
 ax.contour(birth_density_grid, metal_mass_fraction_grid, H.T, levels=6, cmap="Pastel1")
 
 # Add line showing SF law
-sf_threshold_density = star_formation_parameters["threshold_n0"] * (
-    metal_mass_fraction_bins.value / star_formation_parameters["threshold_Z0"]
-) ** (star_formation_parameters["slope"])
-ax.plot(
-    sf_threshold_density,
-    metal_mass_fraction_bins,
-    linestyle="dashed",
-    label="SF threshold",
-)
+if not ("COLIBRE" in ptype):
+    sf_threshold_density = star_formation_parameters["threshold_n0"] * (
+        metal_mass_fraction_bins.value / star_formation_parameters["threshold_Z0"]
+    ) ** (star_formation_parameters["slope"])
+    ax.plot(
+        sf_threshold_density,
+        metal_mass_fraction_bins,
+        linestyle="dashed",
+        label="SF threshold",
+    )
 
 legend = ax.legend(markerfirst=True, loc="lower left")
 plt.setp(legend.get_texts(), color="white")

--- a/plotting/density_temperature.py
+++ b/plotting/density_temperature.py
@@ -12,8 +12,8 @@ from matplotlib.colors import LogNorm
 from matplotlib.animation import FuncAnimation
 
 # Constants; these could be put in the parameter file but are rarely changed.
-density_bounds = [10**(-9.5), 1e4]  # in nh/cm^3
-temperature_bounds = [10 ** (2), 10 ** (9.5)]  # in K
+density_bounds = [10**(-9.5), 1e6]  # in nh/cm^3
+temperature_bounds = [10 ** (0), 10 ** (9.5)]  # in K
 bins = 256
 
 # Plotting controls

--- a/plotting/density_temperature_metals.py
+++ b/plotting/density_temperature_metals.py
@@ -12,8 +12,8 @@ from matplotlib.colors import Normalize
 from matplotlib.animation import FuncAnimation
 
 # Constants; these could be put in the parameter file but are rarely changed.
-density_bounds = [10 ** (-9.5), 1e4]  # in nh/cm^3
-temperature_bounds = [10 ** (2), 10 ** (9.5)]  # in K
+density_bounds = [10 ** (-9.5), 1e6]  # in nh/cm^3
+temperature_bounds = [10 ** (0), 10 ** (9.5)]  # in K
 metallicity_bounds = [-6, -1]  # In metal mass fraction
 min_metallicity = 1e-8
 bins = 256

--- a/plotting/load_sn1a_data.py
+++ b/plotting/load_sn1a_data.py
@@ -27,7 +27,7 @@ class ObservationalData(object):
             self.fitting_formula = False
 
 
-def read_obs_data(path="observational_data"):
+def read_obs_data(path="plotting/sn1a_data"):
     """
     Reads the observational data
     """
@@ -36,6 +36,9 @@ def read_obs_data(path="observational_data"):
 
     hcorr = log10(h) - log10(0.7)  # h^-2 for SFR, h^-3 for volume
 
+    import os
+    cwd = os.getcwd()
+ 
     z, ratenu, sys_err_p, sys_err_m, stat = loadtxt(
         f"{path}/SNIa_rate_frohmaier.dat", unpack=True
     )

--- a/plotting/metallicity_distribution.py
+++ b/plotting/metallicity_distribution.py
@@ -18,6 +18,7 @@ run_name = sys.argv[1]
 run_directory = sys.argv[2]
 snapshot_name = sys.argv[3]
 output_path = sys.argv[4]
+ptype = sys.argv[5]
 
 snapshot_filename = f"{run_directory}/{snapshot_name}"
 
@@ -32,10 +33,16 @@ log_metallicity_bin_width = np.log10(metallicity_bins[1]) - np.log10(
     metallicity_bins[0]
 )
 
-metallicities = {
-    "Gas": data.gas.smoothed_metal_mass_fractions.value,
-    "Stars": data.stars.smoothed_metal_mass_fractions.value,
-}
+if "COLIBRE" in ptype:
+        metallicities = {
+           "Gas": data.gas.metal_mass_fractions.value,
+           "Stars": data.stars.metal_mass_fractions.value,
+        }
+else:
+        metallicities = {
+           "Gas": data.gas.smoothed_metal_mass_fractions.value,
+           "Stars": data.stars.smoothed_metal_mass_fractions.value,
+        }
 
 # Begin plotting
 
@@ -49,7 +56,10 @@ for label, data in metallicities.items():
 
 
 ax.legend(loc="upper right")
-ax.set_xlabel("Smoothed Metal Mass Fractions $Z$ []")
+if "COLIBRE" in ptype:
+        ax.set_xlabel("Metal Mass Fractions $Z$ []")
+else:
+        ax.set_xlabel("Smoothed Metal Mass Fractions $Z$ []")
 ax.set_ylabel("Number of Particles / d$\\log Z$")
 
 fig.savefig(f"{output_path}/metallicity_distribution.png")

--- a/plotting/sn1a_rate.py
+++ b/plotting/sn1a_rate.py
@@ -45,7 +45,7 @@ ax.loglog()
 # Simulation data plotting
 
 # High z-order as we always want these to be on top of the observations
-ax.plot(scale_factor, SNIa_rate, label=name, zorder=10000)
+ax.plot(scale_factor, SNIa_rate, label=run_name, zorder=10000)
 
 # Observational data plotting
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ matplotlib
 astropy
 pyyaml
 cmocean
+attrs
 scipy
 numba
 cachetools

--- a/run.sh
+++ b/run.sh
@@ -15,11 +15,11 @@ ptype="COLIBRE"
 
 isnap_formatted=$( printf '%04d' $isnap )
 # First up, an example for running the scripts on one at a time
-run_directory="/cosma7/data/dp004/dc-ploe1/SIMULATION_RUNS/2020_01_COLIBRE_ref/COLIBRE_L006N0188_ref/"
-run_name="COLIBRE_L006N0188_ref"
-plot_directory="Plots"
+run_directory="/cosma7/data/dp004/dc-ploe1/SIMULATION_RUNS/2020_01_COLIBRE_ref/COLIBRE_L006N0188_steepEOS/"
+run_name="COLIBRE_L006N0188_steepEOS"
+plot_directory="Plots_web"
 snapshot_name="data/snaps/colibre_$isnap_formatted.hdf5"
-catalogue_name="data/stf_bh/halos_$isnap_formatted.properties.0"
+catalogue_name="data/stf_hydr/halos_$isnap_formatted.properties.0"
 
 ln -s $run_directory/colibre_*yml $run_directory/data/snaps/
 
@@ -32,20 +32,20 @@ image_run $run_directory $run_name $plot_directory $snapshot_name $catalogue_nam
 
 plot_single_run () {
   run_name=$1
-  run_directory="Runs/${run_name}"
-  plot_directory="Plots"
+  run_directory="/cosma7/data/dp004/dc-ploe1/SIMULATION_RUNS/2020_01_COLIBRE_ref/${run_name}"
+  plot_directory="Plots_web"
   snapshot_name="data/snaps/colibre_$isnap_formatted.hdf5"
-  catalogue_name="data/stf_bh/halos_$isnap_formatted.properties.0"
+  catalogue_name="data/stf_hydr/halos_$isnap_formatted.properties.0"
 
   mkdir -p $plot_directory/$run_name
 
   # Check if run exists before doing any of this stuff!
   if [[ -f $run_directory/$snapshot_name ]]
   then
-    plot_run $run_directory $run_name $plot_directory $snapshot_name $catalogue_name
-    create_summary_plot $run_directory $run_name $plot_directory $snapshot_name $catalogue_name
+    plot_run $run_directory $run_name $plot_directory $snapshot_name $catalogue_name $ptype
+    create_summary_plot $run_directory $run_name $plot_directory $snapshot_name $catalogue_name $ptype
     image_run $run_directory $run_name $plot_directory $snapshot_name $catalogue_name $ptype
   fi
 }
 
-ls "Runs" | grep Run | parallel -n1 -j56 "plot_single_run ${path}"
+#ls "Runs" | grep Run | parallel -n1 -j56 "plot_single_run ${path}"

--- a/run.sh
+++ b/run.sh
@@ -10,12 +10,16 @@ source image.sh
 # You should have a python environment with requirements.txt installed
 source env/bin/activate
 
+isnap=36
+ptype="COLIBRE"
+
+isnap_formatted=$( printf '%04d' $isnap )
 # First up, an example for running the scripts on one at a time
-run_directory="Runs/Run1"
-run_name="Run1"
-plot_directory="Plots"
-snapshot_name="eagle_0036.hdf5"
-catalogue_name="stf/eagle_0036.properties.0"
+run_directory="/cosma7/data/dp004/dc-ploe1/SIMULATION_RUNS/2020_01_COLIBRE_ref/COLIBRE_L006N0188_ref/"
+run_name="COLIBRE_L006N0188_ref"
+plot_directory="Plots3"
+snapshot_name="data/snaps/colibre_$isnap_formatted.hdf5"
+catalogue_name="data/stf/halos_$isnap_formatted.properties.0"
 
 mkdir -p $plot_directory/$run_name
 plot_run $run_directory $run_name $plot_directory $snapshot_name $catalogue_name
@@ -28,8 +32,8 @@ plot_single_run () {
   run_name=$1
   run_directory="Runs/${run_name}"
   plot_directory="Plots"
-  snapshot_name="eagle_0036.hdf5"
-  catalogue_name="stf/eagle_0036.properties.0"
+  snapshot_name="data/snaps/colibre_$isnap_formatted.hdf5"
+  catalogue_name="data/stf/halos_$isnap_formatted.properties.0"
 
   mkdir -p $plot_directory/$run_name
 
@@ -38,7 +42,7 @@ plot_single_run () {
   then
     plot_run $run_directory $run_name $plot_directory $snapshot_name $catalogue_name
     create_summary_plot $run_directory $run_name $plot_directory $snapshot_name $catalogue_name
-    image_run $run_directory $run_name $plot_directory $snapshot_name $catalogue_name
+    image_run $run_directory $run_name $plot_directory $snapshot_name $catalogue_name $ptype
   fi
 }
 

--- a/run.sh
+++ b/run.sh
@@ -17,14 +17,16 @@ isnap_formatted=$( printf '%04d' $isnap )
 # First up, an example for running the scripts on one at a time
 run_directory="/cosma7/data/dp004/dc-ploe1/SIMULATION_RUNS/2020_01_COLIBRE_ref/COLIBRE_L006N0188_ref/"
 run_name="COLIBRE_L006N0188_ref"
-plot_directory="Plots3"
+plot_directory="Plots"
 snapshot_name="data/snaps/colibre_$isnap_formatted.hdf5"
-catalogue_name="data/stf/halos_$isnap_formatted.properties.0"
+catalogue_name="data/stf_bh/halos_$isnap_formatted.properties.0"
+
+ln -s $run_directory/colibre_*yml $run_directory/data/snaps/
 
 mkdir -p $plot_directory/$run_name
-plot_run $run_directory $run_name $plot_directory $snapshot_name $catalogue_name
-create_summary_plot $run_directory $run_name $plot_directory $snapshot_name $catalogue_name
-image_run $run_directory $run_name $plot_directory $snapshot_name $catalogue_name
+plot_run $run_directory $run_name $plot_directory $snapshot_name $catalogue_name $ptype
+create_summary_plot $run_directory $run_name $plot_directory $snapshot_name $catalogue_name $ptype
+image_run $run_directory $run_name $plot_directory $snapshot_name $catalogue_name $ptype
 
 # Second, baking in a run identifier so we can leverage gnu parallel.
 
@@ -33,7 +35,7 @@ plot_single_run () {
   run_directory="Runs/${run_name}"
   plot_directory="Plots"
   snapshot_name="data/snaps/colibre_$isnap_formatted.hdf5"
-  catalogue_name="data/stf/halos_$isnap_formatted.properties.0"
+  catalogue_name="data/stf_bh/halos_$isnap_formatted.properties.0"
 
   mkdir -p $plot_directory/$run_name
 


### PR DESCRIPTION
Some smaller changes that are useful for COLIBRE and should not do much harm to XL. 
These are all suggestions, but I thought that it's good to have them all in one place. 

Main things are: 

-I added a general variable to run.sh that we could use to distinguish between COLIBRE and XL runs. Then we can use all the same pipeline but the things are very specific to either project would not cause problems for the other. 

- Added some lines in README and requirements.txt that are necessary for me to run the pipeline

- Colorbars are added to the images. No colorbar label yet, though. 

- There is a partype / parttype switch so that both COLIBRE and XL velociraptor output can be read in 

- For COLIBRE plots, only 0.1 Rvir is plotted in the images 

- Temperature - density plots go down to lower temperature and up to higher densities. 