### PR TITLE
Add the stellar mass - stellar age plot to the pipeline

### DIFF
--- a/auto_plotter/ages.yml
+++ b/auto_plotter/ages.yml
@@ -1,0 +1,58 @@
+stellar_mass_stellar_ages_30:
+  type: "scatter"
+  legend_loc: "lower right"
+  y:
+    quantity: "derived_quantities.stellar_ages_yr"
+    log: true
+    units: "yr"
+    start: 1e8
+    end: 2e10
+  x:
+    quantity: "apertures.mass_star_30_kpc"
+    units: solar_mass
+    start: 1e7
+    end: 1e12
+  median:
+    plot: true
+    log: true
+    number_of_bins: 25
+    start:
+      value: 1e7
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+  metadata:
+    title: "Stellar mass - Stellar ages (30 kpc aperture)"
+  observational_data:
+    - filename: ./velociraptor-comparison-data/data/GalaxyStellarMassStellarAges/Gallazzi2005_Data.hdf5
+
+stellar_mass_stellar_ages_100:
+  type: "scatter"
+  legend_loc: "lower right"
+  y:
+    quantity: "derived_quantities.stellar_ages_yr"
+    log: true
+    units: "yr"
+    start: 1e8
+    end: 2e10
+  x:
+    quantity: "apertures.mass_star_100_kpc"
+    units: solar_mass
+    start: 1e7
+    end: 1e12
+  median:
+    plot: true
+    log: true
+    number_of_bins: 25
+    start:
+      value: 1e7
+      units: solar_mass
+    end:
+      value: 1e12
+      units: solar_mass
+  metadata:
+    title: "Stellar mass - Stellar ages (100 kpc aperture)"
+  observational_data:
+    - filename: ./velociraptor-comparison-data/data/GalaxyStellarMassStellarAges/Gallazzi2005_Data.hdf5
+

--- a/data_conversion/index.html
+++ b/data_conversion/index.html
@@ -33,6 +33,7 @@ MathJax.Hub.Config({
     <a href="#sfr_halo">Star Formation Rate-Halo Mass Relation</a>
     <a href="#tullyfisher">Tully-Fisher</a>
     <a href="#metallicity">Gas and Stellar Metallicity</a>
+    <a href="#ages">Stellar Ages</a>
     <a href="#histograms">Histograms</a>
     <a href="#rhot">Density-Temperature</a>
     <a href="#sfh">Star Formation History and SNIa Rate</a>
@@ -172,6 +173,18 @@ MathJax.Hub.Config({
             gas. Metallicity is measured in the same aperture as the stellar
             mass. Gallazzi data is corrected from their choice of solar
             metallicity (0.02) to ours (0.0126).
+        </p>
+    </div>
+
+    <div class="plotrow" id="ages">
+        <h1>Stellar Ages</h1>
+        <div class="plots">
+            <img class="plot" src="stellar_mass_stellar_ages_100.png" />
+        </div>
+        <p>
+	  Stellar ages as a function of stellar mass. No selection is
+	  applied and all the stars in a given given galaxy conribute
+	  to the mean age.
         </p>
     </div>
 

--- a/registration.py
+++ b/registration.py
@@ -20,6 +20,7 @@ This file calculates:
         Metallicity in solar units (relative to metal_mass_fraction).
     + stellar_mass_to_halo_mass_{x}_kpc for 30 and 100 kpc
         Stellar Mass / Halo Mass (mass_200crit) for 30 and 100 kpc apertures.
+    + stellar_ages_yr (no aperture) to assign correct units to the field.
 """
 
 aperture_sizes = [30, 100]
@@ -117,3 +118,9 @@ for aperture_size in aperture_sizes:
     smhm.name = name
 
     setattr(self, f"stellar_mass_to_halo_mass_{aperture_size}_kpc", smhm)
+
+
+stellar_ages = getattr(catalogue.stellar_age, "tage_star")
+stellar_ages = unyt.unyt_array(stellar_ages, units="yr")
+stellar_ages.name = "Mean Stellar Ages $t_*$"
+setattr(self, "stellar_ages_yr", stellar_ages)


### PR DESCRIPTION
Implements #15. 

Note that the units associated to the ages by VR are odd. They seem to be somehow read in as 9 * 10^9 yrs or something like that. I used the registration.py script to clean up and associated the correct units.