### PR TITLE
Comparison plots with adaptive mass function

### DIFF
--- a/useful_extras/create_comparison.py
+++ b/useful_extras/create_comparison.py
@@ -66,16 +66,14 @@ def load_yaml_line_data(
                 # Do we have stellar mass function plots?
                 keys = [key for key in data[name].keys() if key.startswith("stellar_mass_function")]
                 
-                # Any results?
+                # Anything there?
                 for key in keys:
 
                     # Are we plotting the adaptive mass function?
                     adaptive = data[name][key]["lines"].get("adaptive_mass_function",[])
 
-                    # If so, change the key name from adaptive_mass_function to mass_function
+                    # If so, change the key from adaptive_mass_function to mass_function
                     if adaptive:
-
-                        print("double inside")
                         data[name][key]["lines"]["mass_function"] = adaptive
                         data[name][key]["lines"].pop("adaptive_mass_function")
                 


### PR DESCRIPTION
This branch has two updates to `create_comparion.py` script

1) _[important one]_ Recently I have noticed that the make-comparison script was not able to make an adaptive-mass-function plot. The reason is that when the auto plotter is reading `.yml` file, it is looking for `lines:mass_function` but the file provides ` lines:adaptive_mass_function` instead.  Note that this is not a type of the line, which is defined  in a different place in the `.yml` file, but rather the name of the line.

Therefore, to make the script work I manually change the key name from `lines:adaptive_mass_function` to `lines:mass_function`

2) _[minor change]_ We want to make comparison plots look as clear as possible. Hence, there is no need to plot individual data points in the range of the plot where we have binned data points.